### PR TITLE
fix: remove version mark in runtime name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ tsc-test: tsc node_modules src/proto/root.d.ts test-proto src/lib/json/inspector
 .PHONY: build
 build: tsc
 	$(MAKE) -C $(BUILD_PROJ_DIR) noslate turf
-	rm -f .turf/runtime/nodejs-v16/node; ln -s $(BUILD_PROJ_DIR)/out/$(BUILDTYPE)/node .turf/runtime/nodejs-v16/node
+	rm -f .turf/runtime/nodejs/node; ln -s $(BUILD_PROJ_DIR)/out/$(BUILDTYPE)/node .turf/runtime/nodejs/node
 	rm -f .turf/runtime/aworker/aworker; ln -s $(BUILD_PROJ_DIR)/out/$(BUILDTYPE)/aworker .turf/runtime/aworker/aworker
 
 node_modules: package.json

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -42,8 +42,7 @@ if (format === 'csv') {
   const filename = benchmarks[i];
   const child = fork(
     path.resolve(__dirname, filename),
-    cli.test ? [ '--test' ] : [],
-    cli.optional.set
+    cli.test ? [ '--test' ] : cli.optional.set
   );
 
   if (format !== 'csv') {

--- a/fixtures/code_item/node_worker_echo_standard_config.json
+++ b/fixtures/code_item/node_worker_echo_standard_config.json
@@ -50,7 +50,7 @@
     }
   },
   "turf": {
-    "runtime": "nodejs-v16",
+    "runtime": "nodejs",
     "code": "code"
   }
 }

--- a/fixtures/sandbox_simple/config.json
+++ b/fixtures/sandbox_simple/config.json
@@ -45,7 +45,7 @@
     }
   },
   "turf": {
-    "runtime": "nodejs-v16",
+    "runtime": "nodejs",
     "code": "code"
   }
 }

--- a/src/control_plane/__test__/baseline.test.ts
+++ b/src/control_plane/__test__/baseline.test.ts
@@ -19,7 +19,7 @@ const cases = [
     name: 'node_worker_echo_destroy_after_stopping',
     profile: {
       name: 'node_worker_echo',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_echo`,
       handler: 'index.handler',
       signature: 'md5:234234',
@@ -52,7 +52,7 @@ const cases = [
     name: 'node_worker_echo_replica_limit_in_profile_exceeded',
     profile: {
       name: 'node_worker_echo',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_echo`,
       handler: 'index.handler',
       signature: 'md5:234234',
@@ -76,7 +76,7 @@ const cases = [
     name: 'node_worker_echo_replica_limit_in_default_config_exceeded',
     profile: {
       name: 'node_worker_echo',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_echo`,
       handler: 'index.handler',
       signature: 'md5:234234',
@@ -100,7 +100,7 @@ const cases = [
     name: 'node_worker_v8_options',
     profile: {
       name: 'node_worker_v8_options',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_v8_options`,
       handler: 'index.handler',
       signature: 'md5:234234',
@@ -125,7 +125,7 @@ const cases = [
     name: 'node_worker_exec_argv',
     profile: {
       name: 'node_worker_exec_argv',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_v8_options`,
       handler: 'index.handler',
       signature: 'md5:234234',

--- a/src/control_plane/__test__/herald.test.ts
+++ b/src/control_plane/__test__/herald.test.ts
@@ -23,7 +23,7 @@ describe(testName(__filename), () => {
     it('should inspect current function profiles', async () => {
       const expectedProfile = {
         name: 'node_worker_echo',
-        runtime: 'nodejs-v16' as const,
+        runtime: 'nodejs' as const,
         url: `file://${baselineDir}/node_worker_echo`,
         handler: 'index.handler',
         signature: 'md5:234234',

--- a/src/control_plane/herald/impl.ts
+++ b/src/control_plane/herald/impl.ts
@@ -56,7 +56,7 @@ export class HeraldImpl {
        */
       let runtime = profile?.runtime || 'aworker';
       switch (runtime) {
-        case 'nodejs-v16': runtime = 'nodejs'; break;
+        case 'nodejs': runtime = 'nodejs'; break;
         case 'aworker':
         default:
           runtime = 'aworker'; break;

--- a/src/control_plane/starter/nodejs.ts
+++ b/src/control_plane/starter/nodejs.ts
@@ -17,7 +17,7 @@ export class NodejsStarter extends BaseStarter implements WorkerStarter {
 
   constructor(plane: ControlPlane, config: Config) {
     super('nodejs', 'node', 'node starter', plane, config);
-    this.binPath = BaseStarter.findRealBinPath('nodejs-v16', 'node');
+    this.binPath = BaseStarter.findRealBinPath('nodejs', 'node');
   }
 
   _initValidV8Options() {

--- a/src/data_plane/__test__/data_flow_controller.test.ts
+++ b/src/data_plane/__test__/data_flow_controller.test.ts
@@ -25,7 +25,7 @@ describe(common.testName(__filename), function() {
     await roles.agent!.setFunctionProfile([
       {
         name: 'node_worker_echo',
-        runtime: 'nodejs-v16',
+        runtime: 'nodejs',
         url: `file://${baselineDir}/node_worker_echo`,
         handler: 'index.handler',
         signature: 'md5:234234',

--- a/src/data_plane/__test__/service_integrated.test.ts
+++ b/src/data_plane/__test__/service_integrated.test.ts
@@ -66,7 +66,7 @@ describe(common.testName(__filename), function() {
     await agent.setFunctionProfile([
       {
         name: 'node_worker_echo',
-        runtime: 'nodejs-v16',
+        runtime: 'nodejs',
         url: `file://${baselineDir}/node_worker_echo`,
         handler: 'index.handler',
         signature: 'md5:234234',
@@ -98,7 +98,7 @@ describe(common.testName(__filename), function() {
     await agent.setFunctionProfile([
       {
         name: 'node_worker_echo',
-        runtime: 'nodejs-v16',
+        runtime: 'nodejs',
         url: `file://${baselineDir}/node_worker_echo`,
         handler: 'index.handler',
         signature: 'md5:234234',

--- a/src/data_plane/__test__/token_bucket_integrated.test.ts
+++ b/src/data_plane/__test__/token_bucket_integrated.test.ts
@@ -47,7 +47,7 @@ describe(common.testName(__filename), function() {
     await agent.setFunctionProfile([
       {
         name: 'node_worker_echo',
-        runtime: 'nodejs-v16',
+        runtime: 'nodejs',
         url: `file://${baselineDir}/node_worker_echo`,
         handler: 'index.handler',
         signature: 'md5:234234',
@@ -102,7 +102,7 @@ describe(common.testName(__filename), function() {
     await agent.setFunctionProfile([
       {
         name: 'node_worker_echo',
-        runtime: 'nodejs-v16',
+        runtime: 'nodejs',
         url: `file://${baselineDir}/node_worker_echo`,
         handler: 'index.handler',
         signature: 'md5:234234',

--- a/src/data_plane/__test__/worker_broker.test.ts
+++ b/src/data_plane/__test__/worker_broker.test.ts
@@ -15,7 +15,7 @@ import { createDeferred, sleep } from '#self/lib/util';
 
 const PROFILES = [{
   name: 'node-http-demo',
-  runtime: 'nodejs-v16',
+  runtime: 'nodejs',
   url: 'https://noslate-release.oss-cn-hangzhou.aliyuncs.com/demo/node-http-demo.zip',
   handler: 'index.handler',
   initializer: 'index.initializer',

--- a/src/delegate/request_response.ts
+++ b/src/delegate/request_response.ts
@@ -75,8 +75,8 @@ class TriggerResponse extends Readable {
   #metadata;
   constructor(init?: TriggerResponseInit) {
     super({
-      read: init?.read ?? (() => {}),
-      destroy: init?.destroy ?? (() => {}),
+      read: init?.read,
+      destroy: init?.destroy,
     });
     this.#status = init?.status ?? 200;
     let metadata = init?.metadata ?? {};

--- a/src/lib/json/function_profile.d.ts
+++ b/src/lib/json/function_profile.d.ts
@@ -1,6 +1,6 @@
 import { DeepRequired } from '../util';
 
-export type RuntimeType = 'nodejs-v16' | 'aworker';
+export type RuntimeType = 'nodejs' | 'aworker';
 export type ShrinkStrategy = 'FILO' | 'FIFO' | 'LCC';
 
 /**
@@ -45,7 +45,7 @@ interface BaseFunctionProfile {
 }
 
 interface NodejsFunctionProfile extends BaseFunctionProfile, ProcessFunctionProfile {
-  runtime: 'nodejs-v16';
+  runtime: 'nodejs';
   handler: string;
   initializer?: string;
 }

--- a/src/lib/json/function_profile_schema.json
+++ b/src/lib/json/function_profile_schema.json
@@ -118,7 +118,7 @@
         },
         "runtime": {
           "type": "string",
-          "enum": [ "nodejs-v16" ],
+          "enum": [ "nodejs" ],
           "description": "the function runtime"
         },
         "url": {

--- a/src/sdk/__test__/client.test.ts
+++ b/src/sdk/__test__/client.test.ts
@@ -69,7 +69,7 @@ describe(testName(__filename), () => {
     it('should not set profile due to invalid v8 options (nodejs)', async () => {
       const profile: any = {
         name: 'node_worker_v8_options',
-        runtime: 'nodejs-v16',
+        runtime: 'nodejs',
         url: `file://${baselineDir}/node_worker_v8_options`,
         handler: 'index.handler',
         signature: 'md5:234234',

--- a/src/test/api/agent-invoke.test.ts
+++ b/src/test/api/agent-invoke.test.ts
@@ -14,7 +14,7 @@ const item = {
   name: 'node_worker_echo',
   profile: {
     name: 'node_worker_echo',
-    runtime: 'nodejs-v16',
+    runtime: 'nodejs',
     url: `file:///${common.baselineDir}/node_worker_echo`,
     handler: 'index.handler',
     signature: 'md5:234234',

--- a/src/test/baseline/baseline.test.ts
+++ b/src/test/baseline/baseline.test.ts
@@ -25,7 +25,7 @@ const cases = [
     name: 'node_worker_echo',
     profile: {
       name: 'node_worker_echo',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_echo`,
       handler: 'index.handler',
       signature: 'md5:234234',
@@ -44,7 +44,7 @@ const cases = [
     name: 'node_worker_echo_req_metadata',
     profile: {
       name: 'node_worker_echo_req_metadata',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_echo`,
       handler: 'req_metadata.handler',
       signature: 'md5:234234',
@@ -81,7 +81,7 @@ const cases = [
     name: 'node_worker_echo_res_metadata',
     profile: {
       name: 'node_worker_echo_res_metadata',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_echo`,
       handler: 'res_metadata.handler',
       signature: 'md5:234234',
@@ -111,7 +111,7 @@ const cases = [
     name: 'node_worker_echo_with_initializer',
     profile: {
       name: 'node_worker_echo_with_initializer',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_echo`,
       handler: 'with_initializer.handler',
       initializer: 'with_initializer.initializer',
@@ -136,7 +136,7 @@ const cases = [
     name: 'node_worker_dapr_invoke',
     profile: {
       name: 'node_worker_dapr_invoke',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_dapr`,
       handler: 'invoke.handler',
       signature: 'md5:234234',
@@ -157,7 +157,7 @@ const cases = [
     name: 'node_worker_dapr_invoke_non_200_status',
     profile: {
       name: 'node_worker_dapr_invoke',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_dapr`,
       handler: 'invoke.handler',
       signature: 'md5:234234',
@@ -182,7 +182,7 @@ const cases = [
     name: 'node_worker_dapr_binding',
     profile: {
       name: 'node_worker_dapr_binding',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_dapr`,
       handler: 'binding.handler',
       signature: 'md5:234234',
@@ -208,7 +208,7 @@ const cases = [
     name: 'node_worker_dapr_binding_non_200_status',
     profile: {
       name: 'node_worker_dapr_binding',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_dapr`,
       handler: 'binding.handler',
       signature: 'md5:234234',
@@ -238,7 +238,7 @@ const cases = [
     name: 'node_worker_beacon',
     profile: {
       name: 'node_worker_beacon',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_beacon`,
       handler: 'index.handler',
       signature: 'md5:200011',
@@ -593,7 +593,7 @@ const cases = [
     name: 'node_worker_echo_startup_fastfail',
     profile: {
       name: 'node_worker_echo',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_echo`,
       handler: 'index.handler',
       signature: 'md5:234234',
@@ -634,7 +634,7 @@ const cases = [
     },
     profile: {
       name: 'node_worker_echo',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_echo`,
       handler: 'index.handler',
       signature: 'md5:234234',
@@ -655,7 +655,7 @@ const cases = [
     name: 'node_worker_echo_url_404_fastfail',
     profile: {
       name: 'node_worker_echo',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `http://localhost:${ResourceServer.port}/404`,
       handler: 'index.handler',
       signature: 'md5:234234',
@@ -698,7 +698,7 @@ const cases = [
     name: 'node_worker_cwd',
     profile: {
       name: 'node_worker_cwd',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_cwd_symbol_link`,
       handler: 'index.handler',
       signature: 'md5:234234',
@@ -715,7 +715,7 @@ const cases = [
     name: 'node_worker_env',
     profile: {
       name: 'node_worker_env',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_env`,
       handler: 'index.handler',
       signature: 'md5:234234',
@@ -852,7 +852,7 @@ const cases = [
     name: 'node_worker_without_disposable_true',
     profile: {
       name: 'node_worker_without_disposable_true',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_dapr`,
       handler: 'invoke.handler',
       signature: 'md5:234234',
@@ -880,7 +880,7 @@ const cases = [
     name: 'node_worker_with_disposable_true',
     profile: {
       name: 'node_worker_with_disposable_true',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_dapr`,
       handler: 'invoke.handler',
       signature: 'md5:234234',
@@ -973,7 +973,7 @@ const cases = [
     name: 'node_worker_echo_with_request_id',
     profile: {
       name: 'node_worker_echo_with_request_id',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${baselineDir}/node_worker_echo`,
       handler: 'index.handler',
       signature: 'md5:234234',

--- a/src/test/starter/node_worker_bootstrap.test.ts
+++ b/src/test/starter/node_worker_bootstrap.test.ts
@@ -15,7 +15,7 @@ const cases = [
     name: 'node_worker_bootstrap_initializer_not_function',
     profile: {
       name: 'node_worker_bootstrap_initializer_not_function',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${workersDir}/node_worker_bootstrap`,
       handler: 'not_functions.handler',
       initializer: 'not_functions.initializer',
@@ -42,7 +42,7 @@ const cases = [
     name: 'node_worker_bootstrap_handler_not_function',
     profile: {
       name: 'node_worker_bootstrap_handler_not_function',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${workersDir}/node_worker_bootstrap`,
       handler: 'not_functions.handler',
       signature: 'md5:234234',
@@ -62,7 +62,7 @@ const cases = [
     name: 'node_worker_bootstrap_syntax_error_with_initializer',
     profile: {
       name: 'node_worker_bootstrap_syntax_error_with_initializer',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${workersDir}/node_worker_bootstrap`,
       handler: 'syntax_error.handler',
       initializer: 'syntax_error.initializer',
@@ -89,7 +89,7 @@ const cases = [
     name: 'node_worker_bootstrap_syntax_error',
     profile: {
       name: 'node_worker_bootstrap_syntax_error',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${workersDir}/node_worker_bootstrap`,
       handler: 'syntax_error.handler',
       signature: 'md5:234234',

--- a/src/test/starter/node_worker_dapr.test.ts
+++ b/src/test/starter/node_worker_dapr.test.ts
@@ -14,7 +14,7 @@ const cases = [
     name: 'node_worker_dapr_invoke_timeout',
     profile: {
       name: 'node_worker_dapr_invoke_timeout',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${workersDir}/node_worker_dapr`,
       handler: 'timeout.handler',
       signature: 'md5:234234',
@@ -31,7 +31,7 @@ const cases = [
     name: 'node_worker_dapr_invoke_failure',
     profile: {
       name: 'node_worker_dapr_invoke_failure',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${workersDir}/node_worker_dapr`,
       handler: 'failure.handler',
       signature: 'md5:234234',
@@ -48,7 +48,7 @@ const cases = [
     name: 'node_worker_dapr_binding',
     profile: {
       name: 'node_worker_dapr_binding',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${workersDir}/node_worker_dapr`,
       handler: 'binding.handler',
       signature: 'md5:234234',
@@ -65,7 +65,7 @@ const cases = [
     name: 'node_worker_dapr_binding_timeout',
     profile: {
       name: 'node_worker_dapr_binding_timeout',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${workersDir}/node_worker_dapr`,
       handler: 'binding_timeout.handler',
       signature: 'md5:234234',
@@ -82,7 +82,7 @@ const cases = [
     name: 'node_worker_dapr_binding_failure',
     profile: {
       name: 'node_worker_dapr_binding_failure',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${workersDir}/node_worker_dapr`,
       handler: 'binding_failure.handler',
       signature: 'md5:234234',

--- a/src/test/starter/node_worker_timeout.test.ts
+++ b/src/test/starter/node_worker_timeout.test.ts
@@ -14,7 +14,7 @@ const cases = [
     name: 'node_worker_timeout_no_metadata',
     profile: {
       name: 'node_worker_timeout_no_metadata',
-      runtime: 'nodejs-v16',
+      runtime: 'nodejs',
       url: `file://${workersDir}/node_worker_timeout`,
       handler: 'no_metadata.handler',
       signature: 'md5:234234',

--- a/src/test/telemetry-util.ts
+++ b/src/test/telemetry-util.ts
@@ -7,7 +7,7 @@ export const nodeJsWorkerTestItem = {
   name: 'node_worker_echo',
   profile: {
     name: 'node_worker_echo',
-    runtime: 'nodejs-v16',
+    runtime: 'nodejs',
     url: `file:///${baselineDir}/node_worker_echo`,
     handler: 'index.handler',
     signature: 'md5:234234',


### PR DESCRIPTION
It is not possible to define multiple versions for now.