### PR TITLE
deps: pin @grpc/grpc-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@datastructures-js/heap": "4.3.1",
     "@datastructures-js/priority-queue": "6.1.1",
-    "@grpc/grpc-js": "^1.2.12",
+    "@grpc/grpc-js": "1.8.8",
     "@grpc/proto-loader": "^0.5.6",
     "@midwayjs/logger": "^2.16.3",
     "@opentelemetry/api": "^1.3.0",


### PR DESCRIPTION
https://github.com/grpc/grpc-node/releases/tag/%40grpc%2Fgrpc-js%401.8.9 resulted in hanging in `client.waitForReady`.