### PR TITLE
feat: dapr binding response metadata

### DIFF
--- a/fixtures/baseline/aworker_dapr/binding.js
+++ b/fixtures/baseline/aworker_dapr/binding.js
@@ -4,6 +4,8 @@ const dapr = aworker.Dapr['1.0'];
 addEventListener('fetch', event => {
   event.respondWith(Promise.resolve()
     .then(async () => {
+      const operation = event.request.headers.get('DAPR_OPERATION');
+
       const response = await dapr.binding({
         name: 'key-value',
         metadata: {
@@ -14,6 +16,15 @@ addEventListener('fetch', event => {
         operation: event.request.headers.get('DAPR_OPERATION') ?? 'get',
         body: 'foobar',
       });
+
+      if (operation === 'response-metadata') {
+        return new Response(response.body, {
+          headers: {
+            'x-response-data-type': response.metadata.dataType
+          }
+        });
+      }
+
       return response;
     }));
 });

--- a/fixtures/baseline/node_worker_dapr/binding.js
+++ b/fixtures/baseline/node_worker_dapr/binding.js
@@ -12,8 +12,13 @@ exports.handler = async (ctx, req, res) => {
     operation: req.headers.DAPR_OPERATION ?? 'get',
     body: 'foobar',
   });
+
+  res.writeHead(resp.status, {
+    'x-response-data-type': resp?.metadata?.dataType
+  });
+
   res.end(JSON.stringify({
     status: resp.status,
-    text: await resp.text(),
+    text: await resp.text()
   }));
 };

--- a/fixtures/dapr_adaptor/index.js
+++ b/fixtures/dapr_adaptor/index.js
@@ -58,6 +58,14 @@ class DaprAdaptor extends Base {
       };
     }
 
+    if (operation === 'response-metadata') {
+      return {
+        status: 200,
+        data: Buffer.from(JSON.stringify({ foo: 'bar' })),
+        metadata: JSON.stringify({ dataType: 'json' })
+      };
+    }
+
     return {
       status: 500,
       data: Buffer.from('unknown operation'),

--- a/fixtures/dapr_adaptor/index.js
+++ b/fixtures/dapr_adaptor/index.js
@@ -62,7 +62,9 @@ class DaprAdaptor extends Base {
       return {
         status: 200,
         data: Buffer.from(JSON.stringify({ foo: 'bar' })),
-        metadata: JSON.stringify({ dataType: 'json' })
+        metadata: [
+          { key: 'dataType', value: 'json' }
+        ]
       };
     }
 

--- a/fixtures/dapr_adaptor/index.js
+++ b/fixtures/dapr_adaptor/index.js
@@ -62,9 +62,9 @@ class DaprAdaptor extends Base {
       return {
         status: 200,
         data: Buffer.from(JSON.stringify({ foo: 'bar' })),
-        metadata: [
-          { key: 'dataType', value: 'json' }
-        ]
+        metadata: {
+          dataType: 'json'
+        }
       };
     }
 

--- a/src/delegate/dapr_adaptor.ts
+++ b/src/delegate/dapr_adaptor.ts
@@ -14,6 +14,7 @@ export interface DaprAdaptorBindingRequest {
 export interface DaprAdaptorResponse {
   status: number;
   data: Uint8Array;
+  metadata?: Record<string, string | number>;
 }
 
 export interface DaprAdaptor {

--- a/src/delegate/dapr_adaptor.ts
+++ b/src/delegate/dapr_adaptor.ts
@@ -14,7 +14,7 @@ export interface DaprAdaptorBindingRequest {
 export interface DaprAdaptorResponse {
   status: number;
   data: Uint8Array;
-  metadata?: Record<string, string | number>;
+  metadata?: Record<string, string>;
 }
 
 export interface DaprAdaptor {

--- a/src/delegate/invoke_controller.ts
+++ b/src/delegate/invoke_controller.ts
@@ -42,6 +42,7 @@ type CommonCallback = (
     data?: any;
     successOrAcquired?: boolean;
     token?: string;
+    metadata?: Record<string, string | number>
   }
 ) => void;
 
@@ -317,13 +318,13 @@ export class InvokeController {
       return;
     }
     try {
-      const { status, data } = await this.#sharedState.daprAdaptor.binding({
+      const { status, data, metadata } = await this.#sharedState.daprAdaptor.binding({
         name: params.name,
         metadata: JSON.parse(params.metadata),
         operation: params.operation,
         data: params.data,
       });
-      callback(CanonicalCode.OK, null, { status, data });
+      callback(CanonicalCode.OK, null, { status, data, metadata });
     } catch (e) {
       logger.error('dapr binding failed', e);
       callback(CanonicalCode.INTERNAL_ERROR, e as Error);

--- a/src/delegate/noslated_ipc.ts
+++ b/src/delegate/noslated_ipc.ts
@@ -595,7 +595,7 @@ export class NoslatedClient {
 
   daprBinding(
     name: string,
-    metadata: string,
+    metadata: aworker.ipc.IKeyValuePair[],
     operation: string,
     data: Uint8Array,
     timeout: number
@@ -1059,6 +1059,14 @@ export function keyValuePairsToObject(
     obj[kv.key] = kv.value;
   });
   return obj;
+}
+
+export function objectToKeyValuePairs(
+  obj: Record<string, unknown> = {}
+): aworker.ipc.IKeyValuePair[] {
+  return Object.entries(obj).map(([key, value]) => {
+    return { key, value: `${value}` };
+  });
 }
 
 function keyValuePairsToArray(

--- a/src/test/baseline/baseline.test.ts
+++ b/src/test/baseline/baseline.test.ts
@@ -212,6 +212,7 @@ const cases = [
       },
     },
     expect: {
+      status: 500,
       data: JSON.stringify({
         status: 500,
         text: 'unknown operation',

--- a/src/test/e2e/dapr_binding_response_metadata.test.ts
+++ b/src/test/e2e/dapr_binding_response_metadata.test.ts
@@ -1,0 +1,56 @@
+import * as common from '#self/test/common';
+import { testWorker } from '#self/test/util';
+import { DefaultEnvironment } from '#self/test/env/environment';
+import { baselineDir } from '#self/test/common';
+import { AworkerFunctionProfile } from '#self/lib/json/function_profile';
+
+describe(common.testName(__filename), function () {
+  // Debug version of Node.js may take longer time to bootstrap.
+  this.timeout(30_000);
+  const env = new DefaultEnvironment({
+    config: common.extendDefaultConfig({
+      dataPlane: {
+        daprAdaptorModulePath: common.daprAdaptorDir,
+      },
+    }),
+  });
+
+  it('should dapr adaptor binding response with metadata', async () => {
+    const profile: AworkerFunctionProfile = {
+      name: 'aworker_dapr_binding_response',
+      runtime: 'aworker',
+      url: `file://${baselineDir}/aworker_dapr`,
+      sourceFile: 'binding.js',
+      signature: 'md5:234234',
+    };
+
+    await env.agent.setFunctionProfile([profile]);
+
+    function req() {
+      return testWorker(env.agent, {
+        profile,
+        input: {
+          data: Buffer.from(''),
+          metadata: {
+            headers: [['DAPR_OPERATION', 'response-metadata']],
+          },
+        },
+        expect: {
+          status: 200,
+          data: Buffer.from(
+            JSON.stringify({
+              foo: 'bar'
+            })
+          ),
+          metadata: {
+            headers: [
+              ['x-response-data-type', 'json']
+            ]
+          }
+        },
+      });
+    }
+
+    await req();
+  });
+});


### PR DESCRIPTION
AONE#49486996
Related: noslate-project/aworker#34

caller:
```
dapr.binding({
  name: 'demo',
  metadata: {
    foo: 'bar'
  },
  operation: 'get',
  body: 'foobar'
});
```

dapr provider response:
```
return {
  status: 200,
  metadata: {
    dataType: 'json'
  },
  data: Buffer.from('foobar')
};
```
usercode response:
```
const res = await dapr.binding({
  name: 'demo',
  metadata: {
    foo: 'bar'
  },
  operation: 'get',
  body: 'foobar'
});

console.log(res.metadata.dataType);
```
